### PR TITLE
Added Valgrind as an option

### DIFF
--- a/ssat-api.sh
+++ b/ssat-api.sh
@@ -264,7 +264,11 @@ function callCompareTest() {
 ## @param $4 set 1 if this passes if gstLaunch fails.
 ## @param $5 set 1 to enable PERFORMANCE test.
 function gstTest() {
-	calloutput=$(gst-launch-1.0 -f -q $1)
+	if [[ "$VALGRIND" -eq "1" ]]; then
+		calloutputprefix='valgrind --track-origins=yes'
+	fi
+	calloutput=$(eval $calloutputprefix gst-launch-1.0 -f -q $1)
+
 	retcode=$?
 	desired=0
 	if [[ "${4}" -eq "1" ]]; then

--- a/ssat.sh
+++ b/ssat.sh
@@ -41,6 +41,7 @@ TESTCASE="runTest.sh"
 #
 SILENT=1
 PROGRESS=0
+VALGRIND=0
 date=`date +"%b %d %Y"`
 
 ## @fn createTemplate()
@@ -118,6 +119,9 @@ do
 		printf "Show progress during execution\n"
 		printf "    --progress or -p\n"
 		printf "\n"
+		printf "Enable valgrind to perform memcheck\n"
+		printf "    --enable-valgrind or -vg\n"
+		printf "\n"
 		printf "Shows this message\n"
 		printf "    --help or -h\n"
 		printf "    $ ${BASENAME} --help \n"
@@ -143,6 +147,10 @@ do
 	;;
 	-p|--progress)
 	PROGRESS=1
+	shift
+	;;
+	-vg|--enable-valgrind)
+	VALGRIND=1
 	shift
 	;;
 	*) # Unknown, which is probably target (the path to root-dir of test groups).


### PR DESCRIPTION
Valgrind can be enabled by passing --enable-valgrind to ssat
Currently, --full-leaks and --suppressions are not enabled for valgrind

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>