### PR TITLE
[API] Check not only _fail but also _criticalFail when determining PASS

### DIFF
--- a/ssat-api.sh
+++ b/ssat-api.sh
@@ -63,7 +63,7 @@ function writef() {
 ## @fn report()
 ## @brief Report results of a test group (a "runTest.sh" in a testee directory)
 function report() {
-	if (( ${_fail} == 0 ))
+	if (( ${_fail} == 0 && ${_criticalFail} == 0 ))
 	then
 		writef "${Green}==================================================${NC}"
 		writef "${LightGreen}[PASSED]${NC} Test Group $_group ${Green}Passed${NC}"


### PR DESCRIPTION
In some cases, the report function is used to 'literally' report errors that occur in test configuration procedure before terminating the test. For the convenience, this patch makes _criticalFail be also checked when determining PASS/FAIL of the tests. Therefore, to use for reporting critical errors to users or systems, only one variable, _criticalFail, is enough instead of setting both of them.

Signed-off-by: Wook Song <wook16.song@samsung.com>