### PR TITLE
[API] Define SO_EXT that represents filename extension for shared object

### DIFF
--- a/ssat-api.sh
+++ b/ssat-api.sh
@@ -52,8 +52,10 @@ ResultLog=""
 KernelName=$(uname -s)
 if [[ "${KernelName}" == "Darwin" ]]; then
 	StatCmd_GetSize="stat -f %z"
+	SO_EXT="dylib"
 else
 	StatCmd_GetSize="stat --printf=%s"
+	SO_EXT="so"
 fi
 
 ## @fn writef()


### PR DESCRIPTION
A filename extension of a dynamic loadable library could differ between system platforms such as Linux and macOS. In order to consider this issue, this patch defines an environment variable, SO_EXT, which
represents a filename extension for a shared object according to the system platform.

Signed-off-by: Wook Song <wook16.song@samsung.com>