### PR TITLE
[API/compareTest] Return result when files do not exist

### DIFF
--- a/ssat-api.sh
+++ b/ssat-api.sh
@@ -233,6 +233,10 @@ function callTestExitEq() {
 function callCompareTest() {
 	# Try cmp.
 	output=0
+	if [[ ! -f "$1" || ! -f "$2" ]]; then
+		testResult $output "$3" "$4" $6
+		return
+	fi
 	command -v cmp
 	# If cmp is symlink, then it could be from busybox and it does not support "-n" option
 	if [[ $? == 0 && ! -L $(which cmp) ]]


### PR DESCRIPTION
- When the file does not  exist, in BusyBox condition, the bufsize is null and results of `dd` are same error message. And unexpected PASS result follows.
- This patch prevents this unexpected behavior.

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>