### PR TITLE
Update progress mode: use >&2 instead of /dev/stderr

### DIFF
--- a/ssat-api.sh
+++ b/ssat-api.sh
@@ -142,7 +142,7 @@ function testInit() {
 function testResult() {
 	if [[ ${PROGRESSLOGLEVEL} -gt 1 ]]
 	then
-		echo "Case ${2}(${3}) report ${1}" > /dev/stderr
+		echo "Case ${2}(${3}) report ${1}" >&2
 	fi
 
 	_cases=$((_cases+1))


### PR DESCRIPTION
It appears that some Linux distros (gbs-Tizen) does not give
permissions of /dev/stderr for build daemons.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>